### PR TITLE
Check ids instead of the length

### DIFF
--- a/bin/upgrade_analyzer
+++ b/bin/upgrade_analyzer
@@ -163,12 +163,12 @@ module UpgradeAnalyzer
     end
 
     def validate_comparison(results, base_results)
-      if results.length != base_results.length
-        base_ids = base_results.map(&:job_number).sort.join(", ")
-        new_ids = results.map(&:job_number).sort.join(", ")
+        base_ids = base_results.map(&:job_number).sort
+        new_ids = results.map(&:job_number).sort
+      if new_ids != base_ids
         errors << "The Base jobs do not match the jobs in the pull request."
-        errors << "Base jobs: #{base_ids}"
-        errors << "PR jobs:" + "&nbsp;" * 5 + new_ids
+        errors << "Base jobs: #{base_ids.join(', ')}"
+        errors << "PR jobs:" + "&nbsp;" * 5 + new_ids.join(', ')
       end
     end
 


### PR DESCRIPTION
Checking the length isn't as good as checking the ids. We have ran into
examples where two jobs errored so the length was the same but we ended
up comparing the wrong jobs.