### PR TITLE
Errors were being saved between runs

### DIFF
--- a/bin/upgrade_analyzer
+++ b/bin/upgrade_analyzer
@@ -10,14 +10,11 @@ module UpgradeAnalyzer
     UPGRADE_REBASE = "[Upgrade] CI Needed (rebase base branch)"
     UPGRADE_WARNING = "[Upgrade] Check Deprecation Warnings"
 
-    attr_accessor :errors
-
     def initialize(options)
       @options = options
       @github_token = fetch_option(:github_token)
       @listen_mode = options[:listen]
       @repo_name = fetch_option(:repo)
-      @errors = []
     end
 
     def run
@@ -107,10 +104,10 @@ module UpgradeAnalyzer
 
       remove_labels(github)
 
-      validate_comparison(results, base_results)
+      errors = validate_comparison(results, base_results)
 
       if errors.any?
-        report_invalid_comparison(github)
+        report_invalid_comparison(github, errors)
       else
         reports = get_reports(build, results, base_results)
         add_comment_and_labels(reports, github)
@@ -163,6 +160,7 @@ module UpgradeAnalyzer
     end
 
     def validate_comparison(results, base_results)
+      errors = []
       if results.length != base_results.length
         base_ids = base_results.map(&:job_number).sort.join(", ")
         new_ids = results.map(&:job_number).sort.join(", ")
@@ -170,9 +168,10 @@ module UpgradeAnalyzer
         errors << "Base jobs: #{base_ids}"
         errors << "PR jobs:" + "&nbsp;" * 5 + new_ids
       end
+      errors
     end
 
-    def report_invalid_comparison(github)
+    def report_invalid_comparison(github, errors)
       github.add_comment("Upgrade Status: #{errors.join("<br />")}")
       github.add_labels_to_an_issue([UPGRADE_REBASE])
     end


### PR DESCRIPTION
The error instance variable was being saved on the listener class, this
class isn't re-initialized on each run it sits and listens for jobs.
This means that we ended up keeping errors around when they were out of
date.

There are a few things I think we should do to this listener class.
1. Split it up. It is doing too many things. Not only does it listen for
new jobs it also validates, compares, and comments on each job. Each
thing should probably be it's own class
2. Write tests. This class isn't that well tested and I suspect if we
wrote tests first the class wouldn't have grown to be so large.