### PR TITLE
Fix regex for backtrace analyzer

### DIFF
--- a/lib/backtrace_analyzer/analyzer.rb
+++ b/lib/backtrace_analyzer/analyzer.rb
@@ -53,9 +53,9 @@ module BacktraceAnalyzer
     end
 
     def compile_body(failures)
-      failures.flatten.map do |backtrace|
-        trace = backtrace.scan(/^(((?!vendor\/bundle).)*)$/).join
+      failures.flatten.map do |trace|
         trace = trace.strip.gsub(/[ ]{2,}/, "").gsub("\r\r", "\r")
+        trace = trace.scan(/^(?!vendor\/bundle).*$/).join
         ['```', trace, '```'].join("\n")
       end.join("\n")
     end

--- a/test/backtrace_analyzer/analyzer_test.rb
+++ b/test/backtrace_analyzer/analyzer_test.rb
@@ -81,7 +81,7 @@ module BacktraceAnalyzer
       @logger.expects(:info).with('Analyzing PR: 4242')
       @logger.expects(:info).with('Reporting Results')
 
-      expected_comment = "<details>\n<summary>2 test(s) need your attention</summary>\n\n```\nxxxx\n```\n```\nzzzz\n```\n</details>\n"
+      expected_comment = "<details>\n<summary>2 test(s) need your attention</summary>\n\n```\nxxx\n```\n```\nzzz\n```\n</details>\n"
       github.expects(:add_comment).with(expected_comment)
 
       @analyzer.check_build(build)


### PR DESCRIPTION
Simplifies the regex and cleans up the string before scanning it.

Don't ask, it works (tm).

: )