### PR TITLE
Remove color codes from log lines.

### DIFF
--- a/bin/travis_analyzer
+++ b/bin/travis_analyzer
@@ -15,9 +15,10 @@ class TravisAnalyzer
     @travis = TravisConnection.new(github_token, repo_name)
     @listen_mode = options[:listen]
 
-    @log_analyzer = LogAnalyzer::Analyzer.new(@travis, repo_name, github_token)
-    @knapsack_analyzer = KnapsackAnalyzer::Analyzer.new(@travis, repo_name, github_token)
-    @backtrace_analyzer = BacktraceAnalyzer::Analyzer.new(@travis, repo_name, github_token)
+    @analyzers = []
+    @analyzers << LogAnalyzer::Analyzer.new(@travis, repo_name, github_token)
+    @analyzers << KnapsackAnalyzer::Analyzer.new(@travis, repo_name, github_token)
+    @analyzers << BacktraceAnalyzer::Analyzer.new(@travis, repo_name, github_token)
   end
 
   def run
@@ -31,9 +32,9 @@ class TravisAnalyzer
   private
 
   def analyze_build(build)
-    @log_analyzer.check_build(build)
-    @knapsack_analyzer.check_build(build)
-    @backtrace_analyzer.check_build(build)
+    @analyzers.each do |analyzer|
+      analyzer.check_build(build)
+    end
   end
 
   def listen_mode?

--- a/lib/backtrace_analyzer/analyzer.rb
+++ b/lib/backtrace_analyzer/analyzer.rb
@@ -60,6 +60,7 @@ module BacktraceAnalyzer
       failures.flatten.map do |trace|
         trace = trace.strip.gsub(/[ ]{2,}/, "").gsub("\r\r", "\r")
         trace = trace.scan(/^(?!vendor\/bundle).*$/).join
+        trace = trace.strip.gsub(/\e\[[0-9]+m/,"") # remove ascii coloring
         ['```', trace, '```'].join("\n")
       end.join("\n")
     end

--- a/lib/backtrace_analyzer/analyzer.rb
+++ b/lib/backtrace_analyzer/analyzer.rb
@@ -1,3 +1,7 @@
+require_relative "../base_analyzer"
+require_relative "../travis_connection"
+require_relative "../github_proxy"
+
 module BacktraceAnalyzer
   class Analyzer < ::BaseAnalyzer
     def check_build(build)

--- a/lib/knapsack_analyzer/analyzer.rb
+++ b/lib/knapsack_analyzer/analyzer.rb
@@ -3,6 +3,7 @@ require 'json'
 
 require_relative "../base_analyzer"
 require_relative "../travis_connection"
+require_relative "../github_proxy"
 
 module KnapsackAnalyzer
   class Analyzer < ::BaseAnalyzer

--- a/lib/log_analyzer/analyzer.rb
+++ b/lib/log_analyzer/analyzer.rb
@@ -1,5 +1,6 @@
 require_relative "../base_analyzer"
 require_relative "../travis_connection"
+require_relative "../github_proxy"
 require_relative "commenter"
 
 module LogAnalyzer

--- a/lib/upgrade_analyzer/analyzer.rb
+++ b/lib/upgrade_analyzer/analyzer.rb
@@ -7,7 +7,6 @@ require_relative "../github_proxy"
 require_relative "job_result"
 require_relative "result_reporter"
 
-
 module UpgradeAnalyzer
   class Analyzer < ::BaseAnalyzer
 

--- a/test/backtrace_analyzer/analyzer_test.rb
+++ b/test/backtrace_analyzer/analyzer_test.rb
@@ -48,7 +48,7 @@ module BacktraceAnalyzer
       log_body = <<-BODY
         aaa
         FAILED_TEST:START
-        xxx
+        \e[31mxxx\e[0m
         vendor/bundle/makes/it/so/this/line/is/ignored
         FAILED_TEST:END
         yyy


### PR DESCRIPTION
This PR adds some `require` command that was missing since we removed the upgrade_toolbelt_analyzer.

Also:
Some logs from Minitest have escape code to add color to the line.
ie:
````
�[31mFAIL�[0m (0:17:54.477) test_0001_upon logout
````

This commit removes those escape codes.
