### PR TITLE
Knapsack analyzer has issues therefore removing for now

### DIFF
--- a/bin/travis_analyzer
+++ b/bin/travis_analyzer
@@ -5,7 +5,6 @@ require "travis"
 
 require_relative "../lib/log_analyzer/analyzer"
 require_relative "../lib/backtrace_analyzer/analyzer"
-require_relative "../lib/knapsack_analyzer/analyzer"
 
 class TravisAnalyzer
   def initialize(options)
@@ -17,7 +16,6 @@ class TravisAnalyzer
 
     @analyzers = []
     @analyzers << LogAnalyzer::Analyzer.new(@travis, repo_name, github_token)
-    @analyzers << KnapsackAnalyzer::Analyzer.new(@travis, repo_name, github_token)
     @analyzers << BacktraceAnalyzer::Analyzer.new(@travis, repo_name, github_token)
   end
 


### PR DESCRIPTION
Logs: 

![image](https://user-images.githubusercontent.com/750745/37379184-c852f68e-2708-11e8-893d-830d65697edc.png)

It seems it's causing the toolbelt to restart, preventing other analyzers from correctly completing their task.
