### PR TITLE
Fixes undefined method each_pair

### DIFF
--- a/bin/travis_analyzer
+++ b/bin/travis_analyzer
@@ -5,6 +5,8 @@ require "travis"
 
 require_relative "../lib/log_analyzer/analyzer"
 require_relative "../lib/backtrace_analyzer/analyzer"
+require_relative "../lib/knapsack_analyzer/analyzer"
+require_relative "../lib/travis_patch"
 
 class TravisAnalyzer
   def initialize(options)
@@ -16,6 +18,7 @@ class TravisAnalyzer
 
     @analyzers = []
     @analyzers << LogAnalyzer::Analyzer.new(@travis, repo_name, github_token)
+    @analyzers << KnapsackAnalyzer::Analyzer.new(@travis, repo_name, github_token)
     @analyzers << BacktraceAnalyzer::Analyzer.new(@travis, repo_name, github_token)
   end
 

--- a/lib/travis_patch.rb
+++ b/lib/travis_patch.rb
@@ -1,0 +1,32 @@
+# There is a bug in the Travis gem (at least as recent as 1.8.8) that causes it to fail loading the log. The below overrides solve the problem.
+#
+# Ref: https://github.com/travis-ci/travis.rb/issues/578#issuecomment-368142083
+
+class Hash
+  def to_struct
+    Struct.new(*keys).new(*values)
+  end
+end
+
+module Travis
+  module Client
+    class Session
+
+      def load(data)
+        result = {}
+        if data.is_a?(String)
+          return { log: { attributes: { body: data }}.to_struct}.to_struct
+        end
+        (data || {}).each_pair do |key, value|
+          entity = load_entity(key, value)
+          result[key] = entity if entity
+        end
+        result
+      rescue => e
+        puts e.message
+        puts e.backtrace.join("\n")
+      end
+    end
+  end
+end
+# End Travis Overrides


### PR DESCRIPTION
There is a bug in the Travis gem (at least as recent as 1.8.8) that causes it to fail loading the log. The below overrides solve the problem.

/home/ci/bundle/gems/travis-1.8.8/lib/travis/client/session.rb:139:in `load': undefined method `each_pair' for #<String...

Found this workaround here: travis-ci/travis.rb#578 (comment)