### PR TITLE
improve knapsack update trigger

### DIFF
--- a/bin/travis_analyzer
+++ b/bin/travis_analyzer
@@ -15,9 +15,10 @@ class TravisAnalyzer
     @travis = TravisConnection.new(github_token, repo_name)
     @listen_mode = options[:listen]
 
-    @log_analyzer = LogAnalyzer::Analyzer.new(@travis, repo_name, github_token)
-    @knapsack_analyzer = KnapsackAnalyzer::Analyzer.new(@travis, repo_name, github_token)
-    @backtrace_analyzer = BacktraceAnalyzer::Analyzer.new(@travis, repo_name, github_token)
+    @analyzers = []
+    @analyzers << LogAnalyzer::Analyzer.new(@travis, repo_name, github_token)
+    @analyzers << KnapsackAnalyzer::Analyzer.new(@travis, repo_name, github_token)
+    @analyzers << BacktraceAnalyzer::Analyzer.new(@travis, repo_name, github_token)
   end
 
   def run
@@ -31,9 +32,9 @@ class TravisAnalyzer
   private
 
   def analyze_build(build)
-    @log_analyzer.check_build(build)
-    @knapsack_analyzer.check_build(build)
-    @backtrace_analyzer.check_build(build)
+    @analyzers.each do |analyzer|
+      analyzer.check_build(build)
+    end
   end
 
   def listen_mode?

--- a/lib/github_proxy.rb
+++ b/lib/github_proxy.rb
@@ -60,6 +60,19 @@ class GithubProxy
     client.create_pull_request(@repo_name, merge_into_branch, merge_from_branch, title, body)
   end
 
+  def pull_request_open?(merge_into_branch, merge_from_branch)
+    prs = client.pull_requests(@repo_name, state: "open")
+    prs.each do |pr|
+      pr_head_ref = pr[:head][:ref]
+      pr_base_ref = pr[:base][:ref]
+
+      if [merge_into_branch, merge_from_branch] == [pr_base_ref, pr_head_ref]
+        return pr[:number]
+      end
+    end
+    return nil
+  end
+
   private
 
   attr_reader :github_token, :pull_request_number, :repo_name

--- a/lib/knapsack_analyzer/analyzer.rb
+++ b/lib/knapsack_analyzer/analyzer.rb
@@ -18,7 +18,7 @@ module KnapsackAnalyzer
       @knapsack_start = /^Knapsack report was generated/
       @knapsack_end = /^Knapsack global time execution for tests/
 
-      @knapsack_rails_match = /Rails 3.1/
+      @knapsack_rails_match = /Rails 3\.2/
     end
 
     def check_build(build)
@@ -124,13 +124,24 @@ EOF
 
     def knapsack_out_of_date?
       two_weeks_ago = Time.now - 1209600 # 14 days in seconds
-      last_update = github.file_last_update_at(@knapsack_file_path, "heads/#{@knapsack_branch}")
+
+      last_update = nil
+      if pull_request_open?
+        last_update = github.file_last_update_at(@knapsack_file_path, "heads/#{@knapsack_branch}")
+      else
+        last_update = github.file_last_update_at(@knapsack_file_path, "heads/master")
+      end
+
       if last_update > two_weeks_ago
         logger.warn("#{@knapsack_file_path} was last updated on #{last_update.localtime}. Skipping.")
         false
       else
         true
       end
+    end
+
+    def pull_request_open?
+      github.pull_request_open?("master", @knapsack_branch)
     end
 
     def master_branch?(build)

--- a/test/github_proxy_test.rb
+++ b/test/github_proxy_test.rb
@@ -114,4 +114,36 @@ class GithubProxyTest < Minitest::Test
       octomock.verify
     end
   end
+
+  def test_pull_request_open?
+    github = GithubProxy.new("repo", "pr1", "token")
+    octomock = MiniTest::Mock.new
+
+    branches_json = [
+      {
+        head: {ref: "branch_not_it"},
+        base: {ref: "branch1"},
+        number: 1
+      },
+      {
+        head: {ref: "branch2"},
+        base: {ref: "branch_not_it"},
+        number: 2
+      },
+      {
+        head: {ref: "branch2"},
+        base: {ref: "branch1"},
+        number: 3
+      }
+    ]
+
+    octomock.expect(:pull_requests, branches_json, ["repo", state: "open"])
+    octomock.expect(:pull_requests, branches_json, ["repo", state: "open"])
+
+    github.stub(:client, octomock) do
+      assert github.pull_request_open?("branch1", "branch2")
+      assert !github.pull_request_open?("branch1", "branch3")
+      octomock.verify
+    end
+  end
 end


### PR DESCRIPTION
This PR updates the Rails version we use to update the knapsack's json.

Also added a check for an open pr and checks master's last update if
it doesn't exist. This allows us to simply close the knapsack PR and
the next master will trigger an update and create a new PR for us.
(effectively forcing an update)
